### PR TITLE
feat: anchor styling fixed

### DIFF
--- a/src/app/components/footer/footer.component.spec.ts
+++ b/src/app/components/footer/footer.component.spec.ts
@@ -3,13 +3,15 @@ import { ThemeService } from '@services/theme.service';
 
 describe('FooterComponent', () => {
   let component: FooterComponent;
-
-  const themeService = {
-    enableTheme: jest.fn(),
-    availableThemes: () => ['sunny', 'default']
-  } as unknown as ThemeService;
+  let themeService: ThemeService;
 
   beforeEach(() => {
+    themeService = {
+      enableTheme: jest.fn(),
+    } as unknown as ThemeService;
+
+    ThemeService.themes = ['sunny', 'default'];
+
     component = new FooterComponent(themeService);
   });
 

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -20,6 +20,6 @@ export class FooterComponent implements OnInit {
   ngOnInit(): void {
     this.themeService.enableTheme(this.selected);
 
-    this.themes = this.themeService.availableThemes().sort();
+    this.themes = ThemeService.themes.sort();
   }
 }

--- a/src/app/services/theme.service.spec.ts
+++ b/src/app/services/theme.service.spec.ts
@@ -21,34 +21,22 @@ describe('ThemeService', () => {
 
   it('should return an array of the names of the themes available', () => {
     const expected = [
-      'sunny',
       'default',
-      'night'
+      'night',
+      'sunny',
     ];
 
-    const actual = service.availableThemes();
+    const actual = ThemeService.themes;
 
     expect(actual).toEqual(expected);
   });
 
-  it('should set the theme to sunny', () => {
-    service.enableTheme('sunny');
+  ThemeService.themes.forEach(t => {
+    it(`should set the theme to ${t}`, () => {
+      service.enableTheme(t);
 
-    expect(dom.documentElement.style.setProperty).toBeCalledWith('--bg-color', '#ffef67');
-    expect(dom.documentElement.style.setProperty).toBeCalledWith('--txt-color', '#005826');
-  });
-
-  it('should set the theme to default', () => {
-    service.enableTheme('default');
-
-    expect(dom.documentElement.style.setProperty).toBeCalledWith('--bg-color', '#f6f6f6');
-    expect(dom.documentElement.style.setProperty).toBeCalledWith('--txt-color', '#175ea1');
-  });
-
-  it('should set the theme to night', () => {
-    service.enableTheme('night');
-
-    expect(dom.documentElement.style.setProperty).toBeCalledWith('--bg-color', '#333');
-    expect(dom.documentElement.style.setProperty).toBeCalledWith('--txt-color', '#fff');
+      expect(dom.documentElement.style.setProperty).toBeCalledWith('--bg-color', `var(--bg-color-${t})`);
+      expect(dom.documentElement.style.setProperty).toBeCalledWith('--txt-color', `var(--txt-color-${t})`);
+    });
   });
 });

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -1,55 +1,33 @@
 import { Inject, Injectable } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
 
-/* eslint-disable @typescript-eslint/naming-convention */
-export interface ThemeColours {
-  'bg-color': string;
-  'txt-color': string;
-}
-/* eslint-enable */
-
-export type Themes = {
-  [key: string]: ThemeColours;
-};
-
-export type ThemeName = keyof typeof ThemeService.appThemes;
+export type ThemeName = typeof ThemeService.themes[number];
 
 @Injectable({
   providedIn: 'root'
 })
 export class ThemeService {
+  static themes = [
+    'default',
+    'night',
+    'sunny',
+  ];
 
-  /* eslint-disable @typescript-eslint/naming-convention */
-  static appThemes: Themes = {
-    sunny: {
-      'bg-color': '#ffef67',
-      'txt-color': '#005826'
-    } as ThemeColours,
-    default: {
-      'bg-color': '#f6f6f6',
-      'txt-color': '#175ea1'
-    } as ThemeColours,
-    night: {
-      'bg-color': '#333',
-      'txt-color': '#fff'
-    } as ThemeColours
-    /* eslint-enable */
-  };
+  private static themeVariables = [
+    'bg-color',
+    'txt-color',
+  ];
 
   constructor(@Inject(DOCUMENT) private document: Document) { }
 
-  availableThemes(): ThemeName[] {
-    return Object.keys(ThemeService.appThemes);
-  }
-
   enableTheme(theme: ThemeName): void {
-    this.setTheme(ThemeService.appThemes[theme]);
+    this.setTheme(theme);
   }
 
-  private setTheme(theme: ThemeColours): void {
-    Object.keys(theme).forEach((p) => {
-      // @ts-ignore
-      this.document.documentElement.style.setProperty(`--${p}`, theme[p]);
+  private setTheme(themeName: ThemeName): void {
+
+    ThemeService.themeVariables.forEach((p) => {
+      this.document.documentElement.style.setProperty(`--${p}`, `var(--theme-${p}-${themeName})`);
     });
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -9,6 +9,15 @@
   /* theming */
   --bg-color: var(--color-white);
   --txt-color: var(--color-black);
+
+  --theme-bg-color-default: #f6f6f6;
+  --theme-txt-color-default: #175ea1;
+
+  --theme-bg-color-night: #333;
+  --theme-txt-color-night: #fff;
+
+  --theme-bg-color-sunny: #f7ee9e;
+  --theme-txt-color-sunny: #3c3cb6;
 }
 
 body {
@@ -18,14 +27,14 @@ body {
 
   background-color: var(--bg-color);
   color: var(--txt-color);
+}
 
-  a {
-    color: var(--txt-color);
-    text-decoration: underline;
-  }
+a {
+  color: var(--txt-color);
+  text-decoration: underline;
+}
 
-  code {
-    font-family: 'Fira Code', monospace;
-  }
+code {
+  font-family: 'Fira Code', monospace;
 }
 


### PR DESCRIPTION
updated the theme service so it is now more dynamic and uses css variables

Now to add a new theme, is simply a case of:
1. Add the name of it to `ThemeService.themes` array.
2. Add associated `--theme-bg-color-{theme}` & `--theme-txt-color-{theme}` css variables to `src/styles.scss`